### PR TITLE
Document metrics token requirement

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -14,6 +14,8 @@ jobs:
       - name: Isocalendar full year
         uses: lowlighter/metrics@latest
         with:
+          # lowlighter/metrics needs a user-scoped GitHub token for GraphQL profile queries.
+          # The repository-scoped GITHUB_TOKEN is not sufficient for this workflow.
           token: ${{ secrets.METRICS_TOKEN }}
           user: Daniel-Saravia
           template: classic


### PR DESCRIPTION
## Summary
This PR documents the credential requirement for the profile metrics workflow.

The workflow itself was syntactically correct, but recent runs were failing with `401 Bad credentials` when `lowlighter/metrics` attempted the GitHub GraphQL `BaseUser` query for `Daniel-Saravia`. The root cause was an invalid `METRICS_TOKEN`, not the isocalendar configuration.

## Context
`lowlighter/metrics` performs profile-level GraphQL queries that are outside normal repository scope. Because of that, the repository-scoped `GITHUB_TOKEN` is not sufficient for this workflow.

Without that context in the workflow file, it is easy to assume the token can be swapped to `GITHUB_TOKEN` or that the failure is caused by the plugin/rendering options instead of the credential itself.

## Implementation Details
- Added an inline note in `.github/workflows/metrics.yml` above the `token` input.
- Clarified that the workflow needs a user-scoped GitHub token for GraphQL profile queries.
- Clarified that `GITHUB_TOKEN` is not sufficient for this job.

This is intentionally a documentation-only code change. It does not alter scheduling, output filenames, plugin settings, or commit behavior.

## Operational Fix Applied Outside This Diff
The live failure was resolved by rotating the repository secret `METRICS_TOKEN` to a working GitHub token that successfully authenticates the same GraphQL query used by `lowlighter/metrics`.

That secret change lives in repository settings and is therefore not represented in the git diff.

## Validation
- Manually dispatched the `Metrics` workflow after rotating `METRICS_TOKEN`.
- Verified successful completion of run `23120100640`.
- Successful run URL: https://github.com/Daniel-Saravia/Daniel-Saravia/actions/runs/23120100640

## Deployment / Follow-Up Notes
- No application deployment is required.
- No README or SVG content changes are included in this PR.
- Future token rotations should preserve a user-scoped GitHub credential with GraphQL access for `lowlighter/metrics`.
